### PR TITLE
bad variable name fix

### DIFF
--- a/TableInspector.lua
+++ b/TableInspector.lua
@@ -38,7 +38,7 @@ local operatorColor3 = Color3.fromRGB(204, 204, 204)
 
 local highlightColor3 = Color3.fromRGB(255, 183, 0)
 
-local doubleClickPeriod = 1/4
+local doubleClickInterval = 1/4
 
 
 
@@ -553,7 +553,7 @@ function Element:inputBegan(inputObject)
 		return true
 	else
 		local t = os.clock()
-		if t - self._lastExpansionAttempt < doubleClickPeriod and 
+		if t - self._lastExpansionAttempt < doubleClickInterval and 
 			(self._lastExpansionAttemptPosition - getMousePosition()).magnitude < 4 then
 			self:toggleExpansion()
 			return true


### PR DESCRIPTION
Period implies periodicity.
![image](https://github.com/AxisAngles/RobloxTableInspector/assets/3529698/1d4d752f-a22a-43aa-88cc-a0e1669747d2)
Interval is much more accurate.